### PR TITLE
Upgrade analysis tools to latest on lowest dependency runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -28,6 +28,10 @@ jobs:
       - uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependency-versions }}
+
+      - name: Upgrade analysis tools to latest
+        if: ${{ matrix.dependency-versions == 'lowest' }}
+        run: composer update phpstan/phpstan rector/rector phpunit/phpunit --with-all-dependencies --no-interaction
 
       - run: vendor/bin/phpcs
         if: ${{ failure() ||  success() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Upgrade analysis tools to latest
         if: ${{ matrix.dependency-versions == 'lowest' }}
-        run: composer update phpstan/phpstan rector/rector phpunit/phpunit --with-all-dependencies --no-interaction
+        run: composer update phpstan/phpstan rector/rector phpunit/phpunit squizlabs/php_codesniffer --with-all-dependencies --no-interaction
 
       - run: vendor/bin/phpcs
         if: ${{ failure() ||  success() }}


### PR DESCRIPTION
## Summary
- Add a step after `ramsey/composer-install` that upgrades `phpstan/phpstan`, `rector/rector`, and `phpunit/phpunit` to their latest versions when running with lowest dependencies, to avoid false failures from outdated tooling
- Fix CI push trigger branch from `master` to `main`

## Test plan
- [ ] CI passes on lowest and highest dependency runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)